### PR TITLE
feat(hv): implement HV20/HV30 calculator with mock data

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,7 +71,11 @@ model Snapshot {
   marketData   Json
   greeks       Json?
   chainData    Json
+  hv20        Float?    // 20-day historical volatility
+  hv30        Float?    // 30-day historical volatility  
+  hvSource    String?   // Data source (e.g., "yfinance")
   newsEvents   Json?
+  calcAt      DateTime? // When HV was calculated
   
   capturedAt   DateTime @default(now())
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import TickerEntry from "@/components/ui/TickerEntry";
 
 export default function Home() {

--- a/src/components/ui/HvCard.tsx
+++ b/src/components/ui/HvCard.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { AlertCircle, TrendingUp } from 'lucide-react';
+import { fetchDailyCloses } from '@/lib/data';
+import { calculateHVMetrics, HVResult } from '@/lib/hv';
+import { logger } from '@/lib/logger';
+
+interface HvCardProps {
+  ticker: string;
+}
+
+export function HvCard({ ticker }: HvCardProps) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [hvData, setHvData] = useState<HVResult | null>(null);
+
+  useEffect(() => {
+    async function loadHV() {
+      if (!ticker) {
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+      
+      try {
+        // Fetch 35 days to ensure we have enough for HV30
+        const response = await fetchDailyCloses(ticker.toUpperCase(), 35);
+        
+        if (!response.success || !response.data) {
+          setError(response.error || 'Failed to load data');
+          return;
+        }
+
+        const metrics = calculateHVMetrics(response.data.closes);
+        setHvData(metrics);
+        
+        logger.debug('HvCard data loaded', { ticker, metrics });
+      } catch (err) {
+        logger.error('HvCard error', err);
+        setError('Failed to calculate HV');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadHV();
+  }, [ticker]);
+
+  if (!ticker) return null;
+
+  return (
+    <Card className="w-full">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <TrendingUp className="h-4 w-4" />
+          Historical Volatility
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading && (
+          <div className="text-sm text-muted-foreground">
+            Loading HV data...
+          </div>
+        )}
+        
+        {error && (
+          <div className="flex items-center gap-2 text-sm text-destructive">
+            <AlertCircle className="h-4 w-4" />
+            {error}
+          </div>
+        )}
+        
+        {!loading && !error && hvData && (
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <div className="text-xs text-muted-foreground">HV20</div>
+                <div className="text-lg font-semibold">
+                  {hvData.hv20 !== null 
+                    ? `${hvData.hv20.toFixed(1)}%`
+                    : 'N/A'
+                  }
+                </div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">HV30</div>
+                <div className="text-lg font-semibold">
+                  {hvData.hv30 !== null 
+                    ? `${hvData.hv30.toFixed(1)}%`
+                    : 'N/A'
+                  }
+                </div>
+              </div>
+            </div>
+            
+            <div className="text-xs text-muted-foreground">
+              {hvData.dataPoints < 20 && (
+                <div className="text-amber-600 dark:text-amber-500">
+                  Insufficient data ({hvData.dataPoints} days available)
+                </div>
+              )}
+              {hvData.dataPoints >= 20 && (
+                <div>
+                  Calculated: {new Date(hvData.calculatedAt).toLocaleString()}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ui/TickerEntry.tsx
+++ b/src/components/ui/TickerEntry.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Search, TrendingUp, AlertCircle, Loader, RefreshCw, Clock } from 'lucide-react';
+import { HvCard } from '@/components/ui/HvCard';
 
 // Update this to match your backend URL
 const API_BASE_URL = 'http://localhost:5000/api';
@@ -353,14 +354,7 @@ const TickerEntry: React.FC = () => {
             </div>
 
             {/* HV Display */}
-            <div className="bg-blue-50 p-3 rounded-lg mb-4">
-              <p className="text-sm text-blue-800">
-                <strong>Historical Volatility (HV20):</strong> {tickerData.historicalVolatility || 'N/A'}%
-              </p>
-              <p className="text-xs text-gray-600 mt-1">
-                Auto-calculated 20-day volatility. Enter IV manually for comparison.
-              </p>
-            </div>
+            <HvCard ticker={tickerData?.symbol} />
 
             {/* Update Time */}
             <div className="flex items-center justify-between text-xs text-gray-500 mb-4">

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,0 +1,87 @@
+import { logger } from './logger';
+
+export interface PriceData {
+  closes: number[];
+  dates: string[];
+}
+
+export interface DataResponse {
+  success: boolean;
+  data?: PriceData;
+  error?: string;
+}
+
+/**
+ * Fetch daily closing prices for a ticker
+ * TODO: Replace with actual yfinance integration
+ */
+export async function fetchDailyCloses(
+  ticker: string,
+  lookbackDays: number
+): Promise<DataResponse> {
+  logger.debug('fetchDailyCloses', { ticker, lookbackDays });
+
+  try {
+    // Validate inputs
+    if (!ticker || ticker.length === 0) {
+      return { success: false, error: 'Invalid ticker symbol' };
+    }
+
+    if (lookbackDays < 1 || lookbackDays > 365) {
+      return { success: false, error: 'Lookback days must be between 1 and 365' };
+    }
+
+    // TODO: Replace with actual API call
+    // Mock data for testing
+    const mockData = generateMockPrices(ticker, lookbackDays);
+    
+    logger.debug('fetchDailyCloses result', { 
+      ticker, 
+      dataPoints: mockData.closes.length 
+    });
+
+    return {
+      success: true,
+      data: mockData
+    };
+  } catch (error) {
+    logger.error('fetchDailyCloses error', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error'
+    };
+  }
+}
+
+/**
+ * Generate mock price data for testing
+ * Creates realistic-looking price movements
+ */
+function generateMockPrices(ticker: string, days: number): PriceData {
+  const closes: number[] = [];
+  const dates: string[] = [];
+  
+  // Start with a base price based on ticker
+  let basePrice = 100;
+  if (ticker === 'AAPL') basePrice = 150;
+  if (ticker === 'GOOGL') basePrice = 140;
+  if (ticker === 'SPY') basePrice = 450;
+
+  // Generate prices with some volatility
+  let currentPrice = basePrice;
+  const volatility = 0.02; // 2% daily volatility
+  
+  for (let i = days - 1; i >= 0; i--) {
+    // Random walk with slight upward bias
+    const change = (Math.random() - 0.48) * volatility;
+    currentPrice = currentPrice * (1 + change);
+    
+    closes.unshift(currentPrice);
+    
+    const date = new Date();
+    date.setDate(date.getDate() - i);
+    dates.unshift(date.toISOString().split('T')[0]);
+  }
+
+  return { closes, dates };
+}

--- a/src/lib/hv.ts
+++ b/src/lib/hv.ts
@@ -1,0 +1,92 @@
+import { logger } from './logger';
+
+/**
+ * Calculate Historical Volatility using close-to-close log returns
+ * Formula: HV = stdev(ln(P_t/P_{t-1})) * sqrt(252) * 100
+ * 
+ * @param closes Array of closing prices (oldest to newest)
+ * @returns HV as percentage, or null if insufficient data
+ */
+export function calculateHV(closes: number[]): number | null {
+  logger.debug('calculateHV input', { priceCount: closes.length });
+
+  // Need at least 2 prices to calculate returns
+  if (!closes || closes.length < 2) {
+    logger.warn('calculateHV: insufficient data', { count: closes.length });
+    return null;
+  }
+
+  // Validate all prices are positive numbers
+  const invalidPrices = closes.filter(p => !isFinite(p) || p <= 0);
+  if (invalidPrices.length > 0) {
+    logger.error('calculateHV: invalid prices detected', { invalidPrices });
+    return null;
+  }
+
+  // Calculate log returns: ln(P_t / P_{t-1})
+  const logReturns: number[] = [];
+  for (let i = 1; i < closes.length; i++) {
+    const logReturn = Math.log(closes[i] / closes[i - 1]);
+    logReturns.push(logReturn);
+  }
+
+  logger.debug('calculateHV log returns', { 
+    count: logReturns.length,
+    sample: logReturns.slice(0, 3).map(r => r.toFixed(6))
+  });
+
+  // Calculate standard deviation
+  const mean = logReturns.reduce((sum, r) => sum + r, 0) / logReturns.length;
+  const squaredDiffs = logReturns.map(r => Math.pow(r - mean, 2));
+  const variance = squaredDiffs.reduce((sum, d) => sum + d, 0) / (logReturns.length - 1);
+  const stdev = Math.sqrt(variance);
+
+  // Annualize: multiply by sqrt(252) for trading days
+  const annualizedVol = stdev * Math.sqrt(252);
+  
+  // Convert to percentage
+  const hvPercent = annualizedVol * 100;
+
+  logger.debug('calculateHV result', {
+    mean: mean.toFixed(6),
+    stdev: stdev.toFixed(6),
+    annualized: annualizedVol.toFixed(4),
+    hvPercent: hvPercent.toFixed(2)
+  });
+
+  return hvPercent;
+}
+
+/**
+ * Calculate both HV20 and HV30 from price data
+ */
+export interface HVResult {
+  hv20: number | null;
+  hv30: number | null;
+  dataPoints: number;
+  calculatedAt: Date;
+}
+
+export function calculateHVMetrics(closes: number[]): HVResult {
+  const result: HVResult = {
+    hv20: null,
+    hv30: null,
+    dataPoints: closes.length,
+    calculatedAt: new Date()
+  };
+
+  // Calculate HV20 (last 20 days)
+  if (closes.length >= 20) {
+    const last20 = closes.slice(-20);
+    result.hv20 = calculateHV(last20);
+  }
+
+  // Calculate HV30 (last 30 days)
+  if (closes.length >= 30) {
+    const last30 = closes.slice(-30);
+    result.hv30 = calculateHV(last30);
+  }
+
+  logger.debug('calculateHVMetrics result', result);
+  return result;
+}


### PR DESCRIPTION
## Summary

Implements Historical Volatility (HV) calculator for 20-day and 30-day periods using close-to-close log returns. This feature provides automated volatility calculations that traders can compare against implied volatility when making options trading decisions.

## What's Changed

### New Features
- Added HV calculation utility (`lib/hv.ts`) implementing the standard formula: `HV = stdev(ln(P_t/P_{t-1})) * sqrt(252) * 100`
- Created `HvCard` component to display HV20 and HV30 values with loading/error states
- Added data fetcher (`lib/data.ts`) with mock price generator for testing (TODO: integrate yfinance)
- Updated Prisma schema to persist HV data in Snapshot model

### Technical Details
- **Formula**: Annualized volatility using 252 trading days
- **Data**: Currently uses mock data; ready for yfinance integration
- **UI**: Mobile-responsive card showing both HV20 and HV30
- **Error Handling**: Graceful handling of insufficient data (<20 days)

## Notes
- Tests will be added once testing framework is configured
- Mock data generates low volatility; real data integration coming in future issue

## Next Steps
- Issue #5: Manual IV Entry
- Issue #6: IV/HV Comparison Card
- Future: Replace mock data with yfinance historical prices
